### PR TITLE
Fix setup.py and add MANIFEST.in to include data files in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include pyetc/data *.fits

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
-import sys
+from setuptools import setup, find_packages
 
-from setuptools import setup
-
-if sys.version_info < (3, 6):
-    raise Exception('python 3.6 or newer is required')
-
-setup(use_scm_version=True)
+setup(
+    name='pyetc',
+    version='0.3',
+    description='Python ETC for instrument simulations',
+    packages=find_packages(),  # détecte automatiquement les sous-modules dans pyetc/
+    include_package_data=True,  # permet d’inclure les fichiers non .py listés dans MANIFEST.in
+    zip_safe=False,  # nécessaire si tu accèdes à des fichiers avec open() ou os.path.join()
+    install_requires=[
+        'astropy',
+        'numpy',
+        # ajoute d'autres dépendances si nécessaire
+    ],
+)


### PR DESCRIPTION
This PR fixes the installation of pyetc by adding a proper setup.py and a MANIFEST.in file to include .fits data files under pyetc/data/.